### PR TITLE
fix(buttons): add the type of bare in button-icon.

### DIFF
--- a/src/buttons/button-icon.spec.ts
+++ b/src/buttons/button-icon.spec.ts
@@ -1,0 +1,82 @@
+import {it, describe, expect, injectAsync, TestComponentBuilder} from 'angular2/testing';
+import {Component} from 'angular2/core';
+import {NglButtonIcon} from './button-icon';
+
+function getButtonElement(element: Element): HTMLButtonElement {
+  return <HTMLButtonElement>element.querySelector('button');
+}
+
+describe('`nglButtonIcon`', () => {
+
+  it('should render the default button icon when the type is empty', testAsync(
+    `<button [nglButtonIcon]="style"></button>`, ({fixture, done}) => {
+      fixture.detectChanges();
+
+      const button = getButtonElement(fixture.nativeElement);
+      expect(button).toHaveCssClass('slds-button');
+      expect(button).toHaveCssClass('slds-button--icon');
+      done();
+    }));
+
+    it('should render the default button icon when the type is empty and not bind', testAsync(
+    `<button nglButtonIcon=""></button>`, ({fixture, done}) => {
+      fixture.detectChanges();
+
+      const button = getButtonElement(fixture.nativeElement);
+      expect(button).toHaveCssClass('slds-button--icon');
+      done();
+    }));
+
+  it('should render bordered button icon', testAsync(
+    `<button [nglButtonIcon]="style"></button>`, ({fixture, done}) => {
+      fixture.detectChanges();
+
+      const {componentInstance} = fixture;
+      const button = getButtonElement(fixture.nativeElement);
+
+      componentInstance.style = undefined;
+      fixture.detectChanges();
+      expect(button).toHaveCssClass('slds-button--icon-border');
+
+      componentInstance.style = null;
+      fixture.detectChanges();
+      expect(button).toHaveCssClass('slds-button--icon-border');
+
+      done();
+    }));
+
+  it('should render the bordered button icon when the is not set but bind', testAsync(
+    `<button [nglButtonIcon]></button>`, ({fixture, done}) => {
+        fixture.detectChanges();
+
+        const button = getButtonElement(fixture.nativeElement);
+        expect(button).toHaveCssClass('slds-button--icon-border');
+        done();
+    }));
+
+  it('should render the bordered button icon when the is not set at all', testAsync(
+    `<button nglButtonIcon></button>`, ({fixture, done}) => {
+        fixture.detectChanges();
+
+        const button = getButtonElement(fixture.nativeElement);
+        expect(button).toHaveCssClass('slds-button--icon-border');
+        done();
+    }));
+});
+
+// Shortcut function to use instead of `injectAsync` for less boilerplate on each `it`
+function testAsync(html: string, fn: Function) {
+  return injectAsync([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+    return new Promise((done: Function) => {
+      tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => fn({fixture, done}));
+    });
+  });
+}
+
+@Component({
+  directives: [NglButtonIcon],
+  template: '',
+})
+export class TestComponent {
+  style: string = '';
+}

--- a/src/buttons/button-icon.ts
+++ b/src/buttons/button-icon.ts
@@ -6,16 +6,20 @@ import {replaceClass} from '../util/util';
 })
 export class NglButtonIcon {
 
-  private prefix = `slds-button--icon-`;
+  private _type: string = 'slds-button--icon-border';
 
-  private _type: string;
   @Input() set nglButtonIcon(type: 'container' | 'border' | 'border-filled' | 'small') {
-    replaceClass(this, `${this.prefix}${this._type}`, `${this.prefix}${type || 'border'}`);
+    replaceClass(this, this.normalize(this._type), this.normalize(type));
     this._type = type;
   }
 
   constructor(public element: ElementRef, public renderer: Renderer) {
     this.renderer.setElementClass(this.element.nativeElement, 'slds-button', true);
+    this.renderer.setElementClass(this.element.nativeElement, 'slds-button--icon-border', true);
   }
 
-};
+  private normalize(type: string): string {
+    if (!type && type !== '') return 'slds-button--icon-border';
+    return `slds-button--icon${type.length > 0 ? `-${type}` : type}`;
+  }
+}


### PR DESCRIPTION
We need the bare type icons for cases such as the sorting icon in [data tables](https://www.lightningdesignsystem.com/components/data-tables/)