### PR TITLE
fix(NglPill): existence of `nglPillRemove` determines removability

### DIFF
--- a/demo/components/demo/components/pills/pills.html
+++ b/demo/components/demo/components/pills/pills.html
@@ -1,12 +1,12 @@
 <div class="slds-text-heading--label slds-m-bottom--small">Pill examples</div>
 
-<a href="javascript:void(0)" nglPill removable="false">Default</a>
-<a href="javascript:void(0)" nglPill removable="false">
+<a href="javascript:void(0)" nglPill>Default</a>
+<a href="javascript:void(0)" nglPill>
   <svg aria-hidden="true" class="slds-icon slds-icon-standard-account" nglPillImage>
     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="assets/icons/standard-sprite/svg/symbols.svg#account"></use>
   </svg> With icon
 </a>
-<a href="javascript:void(0)" nglPill removable="false">
+<a href="javascript:void(0)" nglPill>
   <span class="slds-avatar slds-avatar--circle" nglPillImage>
     <img src="assets/images/avatar2.jpg" alt="">
   </span>  With portrait
@@ -18,7 +18,7 @@
 <button type="button" nglButton="brand" (click)="add()">Add</button>
 <div class="slds-clearfix slds-p-vertical--xx-small"></div>
 
-<a href="javascript:void(0)" *ngFor="#pill of pills" nglPill (remove)="remove(pill)">
+<a href="javascript:void(0)" *ngFor="#pill of pills" nglPill (nglPillRemove)="remove(pill)">
   <svg aria-hidden="true" class="slds-icon slds-icon-standard-account" nglPillImage>
     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="assets/icons/standard-sprite/svg/symbols.svg#account"></use>
   </svg> {{pill}}

--- a/src/ng-lightning.ts
+++ b/src/ng-lightning.ts
@@ -19,6 +19,7 @@ import {NglPick} from './pick/pick';
 import {NglPickOption} from './pick/pick-option';
 import {NglPill} from './pills/pill';
 import {NglPillImage} from './pills/pill-image';
+import {NglPillRemove} from './pills/pill-remove';
 import {NglPopover} from './popovers/popover';
 import {NglPopoverTrigger} from './popovers/trigger';
 import {NglRating} from './ratings/rating';
@@ -46,6 +47,7 @@ export {NglPick} from './pick/pick';
 export {NglPickOption} from './pick/pick-option';
 export {NglPill} from './pills/pill';
 export {NglPillImage} from './pills/pill-image';
+export {NglPillRemove} from './pills/pill-remove';
 export {NglPopover} from './popovers/popover';
 export {NglPopoverTrigger} from './popovers/trigger';
 export {NglRating} from './ratings/rating';
@@ -65,12 +67,12 @@ export const NGL_DIRECTIVES = [
   NglModal,
   NglPagination,
   NglPick, NglPickOption,
+  NglPill, NglPillImage, NglPillRemove,
   NglPopover, NglPopoverTrigger,
   NglRating,
   NglSection,
   NglSpinner,
   NglTabs, NglTab,
-  NglPill, NglPillImage,
 ];
 
 export {provideNglConfig} from './config/config';

--- a/src/pills/pill-remove.ts
+++ b/src/pills/pill-remove.ts
@@ -1,0 +1,21 @@
+import {Directive, Input} from 'angular2/core';
+import {toBoolean} from '../util/util';
+import {NglPill} from './pill';
+
+@Directive({
+  selector: '[nglPillRemove]',
+})
+export class NglPillRemove {
+
+  @Input() set nglPillRemovable(removable: any) {
+    this.pill.removable = toBoolean(removable);
+  }
+
+  constructor(private pill: NglPill) {}
+
+  ngOnInit() {
+    if (this.pill.removable === undefined) {
+      this.pill.removable = true;
+    }
+  }
+}

--- a/src/pills/pill.spec.ts
+++ b/src/pills/pill.spec.ts
@@ -2,10 +2,11 @@ import {it, describe, expect, injectAsync, TestComponentBuilder} from 'angular2/
 import {Component} from 'angular2/core';
 import {NglPill} from './pill';
 import {NglPillImage} from './pill-image';
+import {NglPillRemove} from './pill-remove';
 import {provideNglConfig} from '../config/config';
 
 function getPill(root: HTMLElement): any {
-  return root.childNodes[1];
+  return root.firstElementChild;
 }
 
 function getIcon(pill: HTMLElement): any {
@@ -17,7 +18,7 @@ function getText(pill: HTMLElement): any {
 }
 
 function getRemoveButton(pill: HTMLElement): any {
-   return pill.childNodes[4];
+   return <HTMLButtonElement>pill.querySelector('button');
 }
 
 describe('NglPill', () => {
@@ -32,17 +33,36 @@ describe('NglPill', () => {
     expect(icon).toHaveCssClass('slds-pill__icon');
     expect(text.textContent.trim()).toBe('I am a pill!');
     expect(removeButton).toHaveCssClass('slds-pill__remove');
+    expect(removeButton).toBe(pill.childNodes[4]);
     done();
   }));
 
-  it('should not render the remove button when [removable] is falsy', testAsync(({fixture, done}) => {
-    fixture.componentInstance.removable = false;
+  it('should not render the remove button without `nglPillRemove`', testAsync(({fixture, done}) => {
     fixture.detectChanges();
     const pill = getPill(fixture.nativeElement);
-    const removeButton = getRemoveButton(pill);
-    expect(removeButton.childNodes.length).toBe(0);
+    expect(getRemoveButton(pill)).toBeNull();
     done();
-  }));
+  }, `<span nglPill></span>`));
+
+  it('should not render the remove button without `nglPillRemove` even with `nglPillRemovable`', testAsync(({fixture, done}) => {
+    fixture.detectChanges();
+    const pill = getPill(fixture.nativeElement);
+    expect(getRemoveButton(pill)).toBeNull();
+    done();
+  }, `<span nglPill nglPillRemovable="true"></span>`));
+
+  it('should toggle the remove button based on `nglPillRemovable`', testAsync(({fixture, done}) => {
+    const pill = getPill(fixture.nativeElement);
+
+    fixture.componentInstance.removable = false;
+    fixture.detectChanges();
+    expect(getRemoveButton(pill)).toBeNull();
+
+    fixture.componentInstance.removable = true;
+    fixture.detectChanges();
+    expect(getRemoveButton(pill)).not.toBeNull();
+    done();
+  }, `<span nglPill (nglPillRemove)="onRemove()" [nglPillRemovable]="removable"></span>`));
 
   it('should trigger the remove event whenever the remove button is clicked', testAsync(({fixture, done}) => {
     fixture.detectChanges();
@@ -69,9 +89,9 @@ function testAsync(fn: Function, html: string = null) {
 }
 
 @Component({
-  directives: [NglPill, NglPillImage],
+  directives: [NglPill, NglPillImage, NglPillRemove],
   template: `
-    <span nglPill (remove)="onRemove()" [removable]="removable">
+    <span nglPill (nglPillRemove)="onRemove()">
       <svg aria-hidden="true" class="slds-icon slds-icon-standard-account" nglPillImage>
         <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/assets/icons/standard-sprite/svg/symbols.svg#account"></use>
       </svg>

--- a/src/pills/pill.ts
+++ b/src/pills/pill.ts
@@ -1,7 +1,6 @@
-import {Component, Input, Output, EventEmitter} from 'angular2/core';
+import {Component, Output, EventEmitter} from 'angular2/core';
 import {NglButtonIcon} from '../buttons/button-icon';
 import {NglIconButton} from '../buttons/icon';
-import {toBoolean} from '../util/util';
 
 @Component({
   selector: '[nglPill]',
@@ -12,15 +11,11 @@ import {toBoolean} from '../util/util';
   },
 })
 export class NglPill {
-  @Input('removable') set setRemovable(removable: any) {
-    this.removable = toBoolean(removable);
-  }
+  removable: boolean;
 
-  @Output('remove') private _remove = new EventEmitter(false);
-
-  private removable = true;
+  @Output() nglPillRemove = new EventEmitter(false);
 
   remove() {
-    this._remove.emit(null);
+    this.nglPillRemove.emit(null);
   }
 }


### PR DESCRIPTION
Remove some verbosity whether close button should exist, and prevent some false positives like:
`<a nglPill removable="true">`, ie when no `(remove)` is defined.