### PR TITLE
fix(build): avoid karma-watch fail due to many watched files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,9 @@ gulp.task('tdd', gulp.series('test:clean-build', function tdd_impl(done) {
     process.exit(1);
   });
 
-  gulp.watch([PATHS.spec, PATHS.templates], gulp.series('test:build'));
+  setTimeout(function() {
+    gulp.watch([PATHS.spec, PATHS.templates], gulp.series('test:build'));
+  }, 1000);
 }));
 
 gulp.task('prepublish', gulp.series('build', function prepublish_impl() {


### PR DESCRIPTION
In windows, due to the low limit of simultaneously opened files, when starting the Karma server and watching for the spec files at the same time an error occurs (please refer to https://github.com/angular/angular/issues/4525). A timeout between starting the Karma server and watching for file changes seems to work around this issue.