### PR TITLE
IE11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you need IE11 support, you'll need to provide the following polyfills. Typica
 * [SVG4Everybody](https://github.com/jonathantneal/svg4everybody)
 * [classList.js](https://github.com/eligrey/classList.js)
 
-** It has been noted that the second polyfill causes considerable slowdown to page rendering when used in Angular dev mode. Using `enableProdMode()` resolves this issue, so make sure you always run in production with this flag! As these polyfills do not affect Chrome or Firefox, it might be worthwhile to utilize those browsers in development. There is **
+** It has been noted that the second polyfill causes considerable slowdown to page rendering when used in Angular dev mode. Using `enableProdMode()` resolves this issue, so make sure you always run in production with this flag! As these polyfills do not affect Chrome or Firefox, it might be worthwhile to utilize those browsers in development.**
 
 ## Usage & Demo
 http://ng-lightning.github.io/ng-lightning/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ If you need IE11 support, you'll need to provide the following polyfills. Typica
 * [SVG4Everybody](https://github.com/jonathantneal/svg4everybody)
 * [classList.js](https://github.com/eligrey/classList.js)
 
+These polyfills are also available via npmcdn.
+
+* [https://npmcdn.com/classlist.js](https://npmcdn.com/classlist.js)
+* [https://npmcdn.com/svg4everybody](https://npmcdn.com/svg4everybody)
+
 ** It has been noted that the second polyfill causes considerable slowdown to page rendering when used in Angular dev mode. Using `enableProdMode()` resolves this issue, so make sure you always run in production with this flag! As these polyfills do not affect Chrome or Firefox, it might be worthwhile to utilize those browsers in development.**
 
 ## Usage & Demo

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ If you use **SystemJS** to load your files, you may want to use our bundle file 
 ```html
 <script src="https://npmcdn.com/ng-lightning@x.x.x/ng-lightning.bundle.js"></script>
 ```
+####Note - IE11 Support
+IE11 does not currently support two important features used by ng-lightning. 
+
+* SVG External Content -- used to load SVG Icons from a sprite map via the `use` tag. See [here](https://css-tricks.com/svg-use-external-source/) for more information.
+* `Element.classList` on SVG elements -- used by Angular's `renderer.setElementClass`. See [here](https://github.com/angular/angular/issues/6327) for more information.
+
+If you need IE11 support, you'll need to provide the following polyfills. Typically, these should be placed within the `head` element, similar to other shims like core-js or reflect-metadata`
+
+* [SVG4Everybody](https://github.com/jonathantneal/svg4everybody)
+* [classList.js](https://github.com/eligrey/classList.js)
+
+** It has been noted that the second polyfill causes considerable slowdown to page rendering when used in Angular dev mode. Using `enableProdMode()` resolves this issue, so make sure you always run in production with this flag! As these polyfills do not affect Chrome or Firefox, it might be worthwhile to utilize those browsers in development. There is **
 
 ## Usage & Demo
 http://ng-lightning.github.io/ng-lightning/


### PR DESCRIPTION
Hi all -- did some digging into IE 11 support. Turns out that binding via `[ngClass]` for SVG class names is the roadblock for IE11 support.

Once I added the two above polyfills, I can run the example project via `enableProdMode()` with no appreciable slowdown.