### PR TITLE
[Datepicker] custom week start

### DIFF
--- a/demo/components/demo/components/datepickers/API.md
+++ b/demo/components/demo/components/datepickers/API.md
@@ -7,6 +7,7 @@
   * `monthNames = ['January', 'February', ...]`: Month names.
   * `dayNamesShort = ['Sun', 'Mon', ...]`: Short form of weekdays.
   * `dayNamesLong = ['Sunday', 'Monday', ...]`: Long form of weekdays.
+  * `firstDayOfWeek: number = 0`: First day of the week. Sunday = 0, Monday = 1, ...
 
 ### Output
 

--- a/demo/components/demo/components/datepickers/datepickers.html
+++ b/demo/components/demo/components/datepickers/datepickers.html
@@ -1,6 +1,12 @@
 <div class="slds-text-title--caps slds-m-bottom--small">Inline {{date | date:'longDate'}}</div>
 
-<button type="button" nglButton="neutral" (click)="gotoDate()" class="slds-m-bottom--large">09 November 2005</button>
-<button type="button" nglButton="destructive" (click)="date = null" class="slds-m-bottom--large">Clear</button>
+<div class="sldl-grid slds-m-bottom--large">
+    <button type="button" nglButton="neutral" (click)="gotoDate()">09 November 2005</button>
+    <button type="button" nglButton="destructive" (click)="date = null">Clear</button>
+</div>
+<div class="sldl-grid slds-m-bottom--large">
+    <button type="button" nglButton="neutral" (click)="firstDayOfWeek = 0">Week start Sunday</button>
+    <button type="button" nglButton="neutral" (click)="firstDayOfWeek = 1">Week start Monday</button>
+</div>
 
-<ngl-datepicker [(date)]="date" class="slds-box slds-box--x-small"></ngl-datepicker>
+<ngl-datepicker [(date)]="date" [firstDayOfWeek]="firstDayOfWeek" class="slds-box slds-box--x-small"></ngl-datepicker>

--- a/demo/components/demo/components/datepickers/datepickers.ts
+++ b/demo/components/demo/components/datepickers/datepickers.ts
@@ -7,6 +7,7 @@ import {Component} from '@angular/core';
 })
 export class DemoDatepickers {
   date: Date;
+  firstDayOfWeek = 0;
 
   gotoDate() {
     this.date = new Date(2005, 10, 9);

--- a/src/datepickers/datepicker.jade
+++ b/src/datepickers/datepicker.jade
@@ -14,7 +14,7 @@
 
 table.datepicker__month(role="grid", [attr.aria-labelledby]="uid + '_month'")
   thead
-    tr(nglWeekdays, [dayNamesShort]="dayNamesShort", [dayNamesLong]="dayNamesLong")
+    tr(nglWeekdays, [firstDayOfWeek]="firstDayOfWeek", [dayNamesShort]="dayNamesShort", [dayNamesLong]="dayNamesLong")
   tbody
     tr(*ngFor="let week of weeks; trackBy:indexTrackBy")
       td(*ngFor="let date of week", (click)="select(date)", [class.slds-is-today]="isActive(date)",

--- a/src/datepickers/datepicker.spec.ts
+++ b/src/datepickers/datepicker.spec.ts
@@ -367,7 +367,7 @@ describe('`Datepicker` Component', () => {
     const currentDate = new Date(2005, 10, 9); // 9 November 2005
     jasmine.clock().mockDate(currentDate);
 
-    const fixture = createTestComponent(`<ngl-datepicker [date]="date" [firstDayOfWeek]="1" showToday="false"></ngl-datepicker>`);
+    const fixture = createTestComponent(`<ngl-datepicker [date]="date" [firstDayOfWeek]="firstDayOfWeek" showToday="false"></ngl-datepicker>`);
 
     expectCalendar(fixture, [
       ['30-', '31-', '01', '02', '03', '04', '05'],
@@ -379,6 +379,21 @@ describe('`Datepicker` Component', () => {
       expect(getDayHeaders(fixture.nativeElement)).toEqual([ 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' ]);
     });
   }));
+
+  it('should not have more than seven days in weekdays', async(() => {
+    const currentDate = new Date(2005, 10, 9); // 9 November 2005
+    jasmine.clock().mockDate(currentDate);
+
+    const fixture = createTestComponent(`<ngl-datepicker [date]="date" [firstDayOfWeek]="firstDayOfWeek" showToday="false"></ngl-datepicker>`);
+
+    expect(getDayHeaders(fixture.nativeElement).length).toEqual(7);
+    fixture.componentInstance.firstDayOfWeek = 0;
+    fixture.detectChanges();
+    expect(getDayHeaders(fixture.nativeElement).length).toEqual(7);
+    fixture.componentInstance.customDays = [ '1', '2', '3', '4', '5', '5', '7' ];
+    fixture.detectChanges();
+    expect(getDayHeaders(fixture.nativeElement).length).toEqual(7);
+  }));
 });
 
 
@@ -389,6 +404,7 @@ export class TestComponent {
   date = new Date(2010, 8, 30); // 30 September 2010
   showToday: boolean;
   dateChange = jasmine.createSpy('dateChange');
+  firstDayOfWeek = 1;
 
   customMonths = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   customDays = [ 'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7' ];

--- a/src/datepickers/datepicker.spec.ts
+++ b/src/datepickers/datepicker.spec.ts
@@ -362,6 +362,23 @@ describe('`Datepicker` Component', () => {
       expect(getDayHeaders(fixture.nativeElement)).toEqual([ 'D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7' ]);
     });
   }));
+
+  it('should support custom week start (firstDayOfWeek)', async(() => {
+    const currentDate = new Date(2005, 10, 9); // 9 November 2005
+    jasmine.clock().mockDate(currentDate);
+
+    const fixture = createTestComponent(`<ngl-datepicker [date]="date" [firstDayOfWeek]="1" showToday="false"></ngl-datepicker>`);
+
+    expectCalendar(fixture, [
+      ['30-', '31-', '01', '02', '03', '04', '05'],
+      ['06', '07', '08', '09', '10', '11', '12'],
+      ['13', '14', '15', '16', '17', '18', '19'],
+      ['20', '21', '22', '23', '24', '25', '26'],
+      ['27', '28', '29', '*30+', '01-', '02-', '03-'],
+    ], 'September', '2010').then(() => {
+      expect(getDayHeaders(fixture.nativeElement)).toEqual([ 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' ]);
+    });
+  }));
 });
 
 

--- a/src/datepickers/datepicker.ts
+++ b/src/datepickers/datepicker.ts
@@ -15,14 +15,12 @@ export type NglInternalDate = { year: number, month: number, day: number, disabl
   styles: [`:host { display: block; }`],
 })
 export class NglDatepicker {
-  date: NglInternalDate;
-  current: NglInternalDate;
-
   @Input() monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
   @Input() dayNamesShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   @Input() dayNamesLong = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursda', 'Friday', 'Saturday'];
-  @Input() firstDayOfWeek = 0; // sunday by default
 
+  date: NglInternalDate;
+  current: NglInternalDate;
   @Input('date') set _date(date: Date) {
     this.date = this.parseDate(date);
     if (this.date) {
@@ -30,13 +28,18 @@ export class NglDatepicker {
     }
     this.render();
   }
+  @Output() dateChange = new EventEmitter();
 
   showToday = true;
   @Input('showToday') set _showToday(showToday: boolean) {
     this.showToday = toBoolean(showToday);
   }
 
-  @Output() dateChange = new EventEmitter();
+  firstDayOfWeek = 0;
+  @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: number) {
+    this.firstDayOfWeek = firstDayOfWeek;
+    this.render();
+  }
 
   weeks: NglInternalDate[];
   uid = uniqueId('datepicker');

--- a/src/datepickers/datepicker.ts
+++ b/src/datepickers/datepicker.ts
@@ -21,6 +21,7 @@ export class NglDatepicker {
   @Input() monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
   @Input() dayNamesShort = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   @Input() dayNamesLong = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursda', 'Friday', 'Saturday'];
+  @Input() firstDayOfWeek = 0; // sunday by default
 
   @Input('date') set _date(date: Date) {
     this.date = this.parseDate(date);
@@ -148,7 +149,7 @@ export class NglDatepicker {
     const offset = first.getDay();
     const last = new Date(year, month, 0).getDate();
 
-    return this.getDayObjects(year, month - 1, last - offset + 1, last, true);
+    return this.getDayObjects(year, month - 1, last - offset + 1 + this.firstDayOfWeek, last, true);
   }
 
   private daysInNextMonth(year: number, month: number, numOfDays: number) {

--- a/src/datepickers/weekdays.ts
+++ b/src/datepickers/weekdays.ts
@@ -14,21 +14,16 @@ export class NglDatepickerWeekdays {
   weekdays: any[] = [];
 
   ngOnChanges() {
-    // add days, starting by the first day of week defined by user
-    for (let i = 0 + this.firstDayOfWeek; i < 7; i++) {
+    let offset = this.firstDayOfWeek;
+    for (let i = 0; i < 7; i++) {
       this.weekdays.push({
         id: `weekday-${i}`,
-        label: this.dayNamesShort[i],
-        title: this.dayNamesLong[i],
+        label: this.dayNamesShort[offset],
+        title: this.dayNamesLong[offset],
       });
-    }
-    // complete with any days preceeding firstDayOfWeek
-    for (let i = 0; i < this.firstDayOfWeek; i++) {
-      this.weekdays.push({
-        id: `weekday-${i}`,
-        label: this.dayNamesShort[i],
-        title: this.dayNamesLong[i],
-      });
+      offset++;
+      if (offset > 6)
+        offset = 0;
     }
   }
 }

--- a/src/datepickers/weekdays.ts
+++ b/src/datepickers/weekdays.ts
@@ -9,11 +9,21 @@ export class NglDatepickerWeekdays {
 
   @Input() dayNamesShort: string[];
   @Input() dayNamesLong: string[];
+  @Input() firstDayOfWeek: number;
 
   weekdays: any[] = [];
 
   ngOnChanges() {
-    for (let i = 0; i < 7; i++) {
+    // add days, starting by the first day of week defined by user
+    for (let i = 0 + this.firstDayOfWeek; i < 7; i++) {
+      this.weekdays.push({
+        id: `weekday-${i}`,
+        label: this.dayNamesShort[i],
+        title: this.dayNamesLong[i],
+      });
+    }
+    // complete with any days preceeding firstDayOfWeek
+    for (let i = 0; i < this.firstDayOfWeek; i++) {
       this.weekdays.push({
         id: `weekday-${i}`,
         label: this.dayNamesShort[i],

--- a/src/datepickers/weekdays.ts
+++ b/src/datepickers/weekdays.ts
@@ -14,16 +14,14 @@ export class NglDatepickerWeekdays {
   weekdays: any[] = [];
 
   ngOnChanges() {
-    let offset = this.firstDayOfWeek;
+    this.weekdays = [];
     for (let i = 0; i < 7; i++) {
+      const offset = (this.firstDayOfWeek + i) % 7;
       this.weekdays.push({
         id: `weekday-${i}`,
         label: this.dayNamesShort[offset],
         title: this.dayNamesLong[offset],
       });
-      offset++;
-      if (offset > 6)
-        offset = 0;
     }
   }
 }


### PR DESCRIPTION
You can now set the first day of the week.

Added a new `@Input` variable `firstDayOfWeek` in `datepicker.ts`. Sunday = 0, so if you want to set Monday as first day of week, just set `firstDayOfWeek="1"` in the ngl-datepicker tag.
Changed `weekday.ts` to reorder weekdays labels accordingly.
Added corresponding test.

Notes:
Did not add consistency check (i.e. if you set firstDayOfWeek = -1234, it should have unexpected bad results).
It's compatible with custom day names (dayNamesShort/dayNamesLong). Those arrays should always start by sunday.

Example of use:

`<ngl-datepicker [(date)]="date" firstDayOfWeek="1" class="slds-box slds-box--x-small"></ngl-datepicker>`