### PR TITLE
fix(datepicker): 2 nasty bugs fix

### DIFF
--- a/src/datepickers/datepicker.spec.ts
+++ b/src/datepickers/datepicker.spec.ts
@@ -387,8 +387,24 @@ describe('`Datepicker` Component', () => {
         ['28', '29', '*30+', '01-', '02-', '03-', '04-'],
       ], 'September', '2010').then(() => {
         expect(getDayHeaders(fixture.nativeElement)).toEqual([ 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun', 'Mon' ]);
+
+        fixture.componentInstance.date = new Date(2017, 0, 19); // 19 January 2017
+        fixture.componentInstance.firstDayOfWeek = 1;
+        //fixture.detectChanges();
+
+        expectCalendar(fixture, [
+          ['26-', '27-', '28-', '29-', '30-', '31-', '01'],
+          ['02', '03', '04', '05', '06', '07', '08'],
+          ['09', '10', '11', '12', '13', '14', '15'],
+          ['16', '17', '18', '*19+', '20', '21', '22'],
+          ['23', '24', '25', '26', '27', '28', '29'],
+          ['30', '31', '01-', '02-', '03-', '04-', '05-'],
+        ], 'January', '2017').then(() => {
+          expect(getDayHeaders(fixture.nativeElement)).toEqual([ 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun' ]);
+        });
       });
     });
+
   }));
 });
 

--- a/src/datepickers/datepicker.spec.ts
+++ b/src/datepickers/datepicker.spec.ts
@@ -390,7 +390,6 @@ describe('`Datepicker` Component', () => {
 
         fixture.componentInstance.date = new Date(2017, 0, 19); // 19 January 2017
         fixture.componentInstance.firstDayOfWeek = 1;
-        //fixture.detectChanges();
 
         expectCalendar(fixture, [
           ['26-', '27-', '28-', '29-', '30-', '31-', '01'],

--- a/src/datepickers/datepicker.ts
+++ b/src/datepickers/datepicker.ts
@@ -37,7 +37,7 @@ export class NglDatepicker {
 
   firstDayOfWeek = 0;
   @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: any) {
-    this.firstDayOfWeek = (typeof firstDayOfWeek) === 'number' ? firstDayOfWeek : parseInt(firstDayOfWeek);
+    this.firstDayOfWeek = +firstDayOfWeek;
     this.render();
   }
 

--- a/src/datepickers/datepicker.ts
+++ b/src/datepickers/datepicker.ts
@@ -36,8 +36,8 @@ export class NglDatepicker {
   }
 
   firstDayOfWeek = 0;
-  @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: number) {
-    this.firstDayOfWeek = firstDayOfWeek;
+  @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: any) {
+    this.firstDayOfWeek = (typeof firstDayOfWeek) === 'number' ? firstDayOfWeek : parseInt(firstDayOfWeek);
     this.render();
   }
 
@@ -149,7 +149,9 @@ export class NglDatepicker {
 
   private daysInPreviousMonth(year: number, month: number) {
     const first = new Date(year, month, 1);
-    const offset = first.getDay();
+    let offset = first.getDay();
+    if (offset === 0 && this.firstDayOfWeek !== 0)
+      offset = 7;
     const last = new Date(year, month, 0).getDate();
 
     return this.getDayObjects(year, month - 1, last - offset + 1 + this.firstDayOfWeek, last, true);

--- a/src/datepickers/datepicker.ts
+++ b/src/datepickers/datepicker.ts
@@ -36,7 +36,7 @@ export class NglDatepicker {
   }
 
   firstDayOfWeek = 0;
-  @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: any) {
+  @Input('firstDayOfWeek') set _firstDayOfWeek(firstDayOfWeek: number) {
     this.firstDayOfWeek = +firstDayOfWeek;
     this.render();
   }


### PR DESCRIPTION
1) Type check of `firstDayOfWeek` when assigning:
In a template if you write `<ngl-datepicker firstDayOfWeek="1" ...`, `firstDayOfWeek` is actually a string. Next in `weekdays.ts` the calculation `const offset = (this.firstDayOfWeek + i) % 7;` is interpreted as `("1" + i) % 7` which gives for example with `i=0  => "10" % 7 = 3`...

2) Handle a special case where first day of month = sunday = 0 and `firstDayOfWeek != 0` in 'daysInPreviousMonth' function:
In this special case (well not so special):
`last - offset + 1 + this.firstDayOfWeek // with offset = 0 and firstDayOfWeek > 0` always > last day of the previous month, cascading with no days added at the beginning of the calendar.

Sorry for letting such nasty bugs in previous commit.
