### PR TITLE
added preventDefault to nglDropdownTrigger on button click

### DIFF
--- a/src/menus/dropdown-trigger.ts
+++ b/src/menus/dropdown-trigger.ts
@@ -18,7 +18,8 @@ export class NglDropdownTrigger implements OnDestroy {
     this.parentFocusEventSubscription.unsubscribe();
   }
 
-  @HostListener('click') toggleOpen() {
+  @HostListener('click', ['$event']) toggleOpen($event: Event) {
+    $event.preventDefault();
     this.dropdown.toggle();
   }
 


### PR DESCRIPTION
While using menus component inside a form element, on menu open click, nglDropdownTrigger does not preventDefault and triggers sending form behavior. This pull request fixes it.