### PR TITLE
fix(modal): remove stopPropagation on click events

### DIFF
--- a/src/modals/modal.ts
+++ b/src/modals/modal.ts
@@ -55,11 +55,6 @@ export class NglModal {
     this.openChange.emit(false);
   }
 
-  @HostListener('click', ['$event'])
-  stopPropagation(evt: Event) {
-    evt.stopPropagation();
-  }
-
   focusFirst() {
     this.closeButton.nativeElement.focus();
   }


### PR DESCRIPTION
dropdowns inside modals arent able to close on global clicks.
I would suggest the removal of stopPropagation (which fixes this) if there is no good reason for it.