### PR TITLE
feat(popovers): make nglPopoverBehavior optionally controllable with data binding

### DIFF
--- a/demo/src/app/components/demo/forms/API.md
+++ b/demo/src/app/components/demo/forms/API.md
@@ -3,6 +3,7 @@
 ### Input
   * `label?: string | TemplateRef`: Input label.
   * `error?: string`: Error message.
+  * `tooltipHelp?: string`: Inline help tooltip.
 
 ### Content
 

--- a/demo/src/app/components/demo/forms/forms.html
+++ b/demo/src/app/components/demo/forms/forms.html
@@ -9,7 +9,7 @@
   <input nglFormControl type="text" placeholder="My input" [required]="required">
 </ngl-form-element>
 
-<ngl-form-element [error]="hasError ? error : null" class="slds-m-top--small">
+<ngl-form-element tooltipHelp="Some helpful information" [error]="hasError ? error : null" class="slds-m-top--small">
   <ng-template nglFormLabel><i>Textarea Label</i> <span *ngIf="required">(<b>required</b>!)</span></ng-template>
   <textarea nglFormControl placeholder="Placeholder Text" [required]="required"></textarea>
 </ngl-form-element>

--- a/src/datatables/datatable.ts
+++ b/src/datatables/datatable.ts
@@ -89,6 +89,9 @@ export class NglDatatable {
   }
 
   ngOnDestroy() {
-    this._columnsSubscription.unsubscribe();
+    if (this._columnsSubscription) {
+      this._columnsSubscription.unsubscribe();
+      this._columnsSubscription = null;
+    }
   }
 };

--- a/src/forms/elements/element.pug
+++ b/src/forms/elements/element.pug
@@ -1,6 +1,10 @@
 label.slds-form-element__label([attr.for]="uid")
   abbr.slds-required(*ngIf="required", title="required") *
   span([nglInternalOutlet]="_label")
+.slds-form-element__icon(*ngIf="tooltipHelp")
+  a([nglPopover]="tooltipHelp", nglPopoverBehavior, nglPopoverPlacement="top", nglTooltip)
+    svg.slds-icon.slds-icon--x-small.slds-icon-text-default(nglIcon="info")
+  span.slds-assistive-text Help
 .slds-form-element__control
   ng-content
 .slds-form-element__help(*ngIf="error", [id]="'error_' + uid") {{error}}

--- a/src/forms/elements/element.ts
+++ b/src/forms/elements/element.ts
@@ -19,6 +19,8 @@ export class NglFormElement implements OnChanges, AfterContentInit {
   @Input('label') labelStr: string;
   @ContentChild(NglFormLabelTemplate) labelTpl: NglFormLabelTemplate;
 
+  @Input() tooltipHelp: string;
+
   @Input() error: string;
 
   uid = uniqueId('form_element');

--- a/src/forms/elements/input.spec.ts
+++ b/src/forms/elements/input.spec.ts
@@ -71,6 +71,15 @@ describe('`NglFormInput`', () => {
     expect(() => createTestComponent(`<ngl-form-element><input type="input"></ngl-form-element>`)).toThrowError();
   });
 
+  it('should support tooltip', () => {
+    const fixture = createTestComponent(`<ngl-form-element tooltipHelp="Field Help"><input nglFormControl type="text"></ngl-form-element>`);
+
+    const helpEl = fixture.nativeElement.querySelector('.slds-form-element__icon');
+    expect(helpEl).toBeTruthy();
+    const assistiveEl = helpEl.querySelector('.slds-assistive-text');
+    expect(assistiveEl).toHaveText('Help');
+  });
+
 });
 
 @Component({

--- a/src/forms/module.ts
+++ b/src/forms/module.ts
@@ -1,6 +1,8 @@
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NglInternalOutletModule} from '../util/outlet.module';
+import {NglPopoversModule} from '../popovers/module';
+import {NglIconsModule} from '../icons/module';
 
 import {NglFormElement} from './elements/element';
 import {NglFormElementCheckbox} from './elements/checkbox';
@@ -26,6 +28,6 @@ const NGL_FORM_DIRECTIVES = [
 @NgModule({
   declarations: NGL_FORM_DIRECTIVES,
   exports: NGL_FORM_DIRECTIVES,
-  imports: [CommonModule, NglInternalOutletModule],
+  imports: [CommonModule, NglInternalOutletModule, NglPopoversModule, NglIconsModule],
 })
 export class NglFormsModule {}

--- a/src/popovers/behavior.spec.ts
+++ b/src/popovers/behavior.spec.ts
@@ -4,21 +4,24 @@ import {createGenericTestComponent, dispatchEvent} from '../../test/util/helpers
 import {NglPopoversModule} from './module';
 import {getPopoverElement} from './popover.spec';
 
-const createTestComponent = (html?: string, detectChanges?: boolean) =>
-  createGenericTestComponent(TestComponent, html, detectChanges) as ComponentFixture<TestComponent>;
+const createUnboundTestComponent = (html?: string, detectChanges?: boolean) =>
+  createGenericTestComponent(TestComponentWithoutBinding, html, detectChanges) as ComponentFixture<TestComponentWithoutBinding>;
 
-describe('`NglPopoverBehavior`', () => {
+const createDataBoundTestComponent = (html?: string, detectChanges?: boolean) =>
+  createGenericTestComponent(TestComponentWithBinding, html, detectChanges) as ComponentFixture<TestComponentWithBinding>;
 
-  beforeEach(() => TestBed.configureTestingModule({declarations: [TestComponent], imports: [NglPopoversModule]}));
+describe('`NglPopoverBehavior` without binding', () => {
+
+  beforeEach(() => TestBed.configureTestingModule({declarations: [TestComponentWithoutBinding], imports: [NglPopoversModule]}));
 
   it('should add `tabindex` to make it focusable', () => {
-    const fixture = createTestComponent();
+    const fixture = createUnboundTestComponent();
     const triggerEl = fixture.nativeElement.firstElementChild;
     expect(triggerEl.getAttribute('tabindex')).toBe('0');
   });
 
   it('should change visibility based on mouse', () => {
-    const fixture = createTestComponent();
+    const fixture = createUnboundTestComponent();
     const triggerEl = fixture.nativeElement.firstElementChild;
     dispatchEvent(triggerEl, 'mouseenter');
     expect(getPopoverElement(fixture.nativeElement)).toBeTruthy();
@@ -28,7 +31,7 @@ describe('`NglPopoverBehavior`', () => {
   });
 
   it('should change visibility based on focus', () => {
-    const fixture = createTestComponent();
+    const fixture = createUnboundTestComponent();
     const triggerEl = fixture.nativeElement.firstElementChild;
     dispatchEvent(triggerEl, 'focus');
     expect(getPopoverElement(fixture.nativeElement)).toBeTruthy();
@@ -38,11 +41,89 @@ describe('`NglPopoverBehavior`', () => {
   });
 
   it('should create more than one instances', () => {
-    const fixture = createTestComponent();
+    const fixture = createUnboundTestComponent();
     const triggerEl = fixture.nativeElement.firstElementChild;
     dispatchEvent(triggerEl, 'focus');
     dispatchEvent(triggerEl, 'mouseenter');
     expect(fixture.nativeElement.querySelectorAll('ngl-popover').length).toBe(1);
+  });
+});
+
+describe('`NglPopoverBehavior` with binding', () => {
+
+  beforeEach(() => TestBed.configureTestingModule({declarations: [TestComponentWithBinding], imports: [NglPopoversModule]}));
+
+  it('should change visibility based on mouse when enabled', () => {
+    const fixture = createDataBoundTestComponent();
+    const triggerEl = fixture.nativeElement.firstElementChild;
+
+    fixture.componentInstance.enablePopoverBehavior = true;
+    fixture.detectChanges();
+
+    dispatchEvent(triggerEl, 'mouseenter');
+    expect(getPopoverElement(fixture.nativeElement)).toBeTruthy();
+
+    dispatchEvent(triggerEl, 'mouseleave');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+  });
+
+  it('should not change visibility based on mouse when disabled', () => {
+    const fixture = createDataBoundTestComponent();
+    const triggerEl = fixture.nativeElement.firstElementChild;
+
+    fixture.componentInstance.enablePopoverBehavior = false;
+    fixture.detectChanges();
+
+    dispatchEvent(triggerEl, 'mouseenter');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+
+    dispatchEvent(triggerEl, 'mouseleave');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+  });
+
+  it('should change visibility based on focus when enabled', () => {
+    const fixture = createDataBoundTestComponent();
+    const triggerEl = fixture.nativeElement.firstElementChild;
+
+    fixture.componentInstance.enablePopoverBehavior = true;
+    fixture.detectChanges();
+
+    dispatchEvent(triggerEl, 'focus');
+    expect(getPopoverElement(fixture.nativeElement)).toBeTruthy();
+
+    dispatchEvent(triggerEl, 'blur');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+  });
+
+  it('should not change visibility based on focus when disabled', () => {
+    const fixture = createDataBoundTestComponent();
+    const triggerEl = fixture.nativeElement.firstElementChild;
+
+    fixture.componentInstance.enablePopoverBehavior = false;
+    fixture.detectChanges();
+
+    dispatchEvent(triggerEl, 'focus');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+
+    dispatchEvent(triggerEl, 'blur');
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
+  });
+
+
+  it('should close if disabled after opening', () => {
+    const fixture = createDataBoundTestComponent();
+    const triggerEl = fixture.nativeElement.firstElementChild;
+
+    fixture.componentInstance.enablePopoverBehavior = true;
+    fixture.detectChanges();
+
+    dispatchEvent(triggerEl, 'focus');
+    expect(getPopoverElement(fixture.nativeElement)).toBeTruthy();
+
+    fixture.componentInstance.enablePopoverBehavior = false;
+    fixture.detectChanges();
+
+    expect(getPopoverElement(fixture.nativeElement)).toBeFalsy();
   });
 });
 
@@ -52,4 +133,15 @@ describe('`NglPopoverBehavior`', () => {
     <span [nglPopover]="tip" nglPopoverBehavior>Open here</span>
   `,
 })
-export class TestComponent {}
+export class TestComponentWithoutBinding {}
+
+
+@Component({
+  template: `
+    <ng-template #tip>I am a tooltip</ng-template>
+    <span [nglPopover]="tip" [nglPopoverBehavior]="enablePopoverBehavior">Open here</span>
+  `,
+})
+export class TestComponentWithBinding {
+  public enablePopoverBehavior: boolean;
+}

--- a/src/popovers/behavior.ts
+++ b/src/popovers/behavior.ts
@@ -1,10 +1,13 @@
-import {Directive, HostListener, HostBinding} from '@angular/core';
+import {Directive, HostListener, HostBinding, Input, OnChanges, SimpleChanges} from '@angular/core';
 import {NglPopoverTrigger} from './trigger';
 
 @Directive({
   selector: '[nglPopover][nglPopoverBehavior]',
 })
-export class NglPopoverBehavior {
+export class NglPopoverBehavior implements OnChanges {
+
+  @Input('nglPopoverBehavior')
+  public isBehaviorEnabled?: boolean;
 
   @HostBinding('attr.tabindex') tabindex = 0;
 
@@ -13,7 +16,7 @@ export class NglPopoverBehavior {
   @HostListener('mouseenter')
   @HostListener('focus')
   onMouseOver() {
-    this.trigger.nglOpen = true;
+    this.trigger.nglOpen = this.isBehaviorEnabled !== false;
   }
 
   @HostListener('mouseleave')
@@ -21,4 +24,10 @@ export class NglPopoverBehavior {
   onMouseOut() {
     this.trigger.nglOpen = false;
   }
-};
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.isBehaviorEnabled && this.isBehaviorEnabled === false) {
+      this.trigger.nglOpen = false;
+    }
+  }
+}


### PR DESCRIPTION
When creating popovers with bound data in the content of the popover, there are sometimes cases where missing data should prevent the popover from displaying.  Since the popover allows full templates, it is not simple to suppress the popover when the content is `undefined` (e.g. the template may be defined, but some variable used inside the template is not)

To support this use case, this change extends the `nglPopoverBehavior` to optionally allow data binding to a `boolean` value.  This allows the behavior to be controlled dynamically if needed.