### PR TITLE
feat(popovers/tooltips): support more complex placements

### DIFF
--- a/projects/ng-lightning/src/lib/common/host/host.service.ts
+++ b/projects/ng-lightning/src/lib/common/host/host.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Renderer2, RendererFactory2, ElementRef } from '@angular/co
 @Injectable()
 export class HostService {
   private classMap = {};
+  private styleMap = {};
   private renderer: Renderer2;
 
   updateClass({ nativeElement }: ElementRef, classMap: object): void {
@@ -24,6 +25,24 @@ export class HostService {
     Object.keys(remove).filter(i => remove[i]).forEach(i => this.renderer.removeClass(nativeElement, i));
 
     this.classMap = newClassMap;
+  }
+
+  updateStyle({ nativeElement }: ElementRef, styleMap: object): void {
+    const remove = { ...this.styleMap };
+
+    Object.keys(styleMap).filter(i => styleMap[i]).forEach(i => {
+      if (styleMap[i] !== false) {
+        this.renderer.setStyle(nativeElement, i, styleMap[i]);
+      }
+
+      if (remove[i]) {
+        delete remove[i];
+      }
+    });
+
+    Object.keys(remove).forEach(i => this.renderer.removeStyle(nativeElement, i));
+
+    this.styleMap = styleMap;
   }
 
   constructor(rendererFactory2: RendererFactory2) {

--- a/projects/ng-lightning/src/lib/popovers/popover.spec.ts
+++ b/projects/ng-lightning/src/lib/popovers/popover.spec.ts
@@ -32,6 +32,12 @@ function getAssistiveTextEl(element: HTMLElement): HTMLElement {
   return <HTMLElement>element.querySelector('.slds-assistive-text');
 }
 
+export function expectPlacementStyles(element: HTMLElement, styles: any) {
+  const { top, right, bottom, left } = element.style;
+  const expected = [styles.top, styles.right, styles.bottom, styles.left].map(e => e || '');
+  expect([top, right, bottom, left]).toEqual(expected);
+}
+
 function getOutsidePopoverElement(element: HTMLElement): HTMLElement {
   return <HTMLElement>element.children[1];
 }
@@ -76,22 +82,35 @@ describe('Popovers', () => {
     expect(popoverEl).toBeFalsy();
   });
 
-  it('should change nubbin based on placement', () => {
+  it('should change nubbin and styles based on placement', () => {
     fixture = createTestComponent();
     const { componentInstance } = fixture;
     const popoverEl = getPopoverElement();
 
     expect(popoverEl).toHaveCssClass('slds-nubbin_bottom');
+    expectPlacementStyles(popoverEl, { bottom: '1rem'});
 
     componentInstance.placement = 'left';
     fixture.detectChanges();
     expect(popoverEl).toHaveCssClass('slds-nubbin_right');
     expect(popoverEl).not.toHaveCssClass('slds-nubbin_bottom');
+    expectPlacementStyles(popoverEl, { right: '1rem' });
+
+    componentInstance.placement = 'right-top';
+    fixture.detectChanges();
+    expect(popoverEl).toHaveCssClass('slds-nubbin_left-top');
+    expectPlacementStyles(popoverEl, { left: '1rem', top: '-1.5rem' });
+
+    componentInstance.placement = 'left-bottom';
+    fixture.detectChanges();
+    expect(popoverEl).toHaveCssClass('slds-nubbin_right-bottom');
+    expectPlacementStyles(popoverEl, { right: '1rem', bottom: '-1.5rem' });
 
     componentInstance.placement = 'bottom';
     fixture.detectChanges();
     expect(popoverEl).toHaveCssClass('slds-nubbin_top');
     expect(popoverEl).not.toHaveCssClass('slds-nubbin_right');
+    expectPlacementStyles(popoverEl, { top: '1rem' });
   });
 
   it('should change variant based on input', () => {

--- a/projects/ng-lightning/src/lib/popovers/popover.ts
+++ b/projects/ng-lightning/src/lib/popovers/popover.ts
@@ -97,11 +97,16 @@ export class NglPopover implements OnInit, OnDestroy {
 
   private setHostClass() {
     this.hostService.updateClass(this.element, {
-      [`slds-nubbin_${this._nubbin}`]: !!this._nubbin,
-      [`slds-m-${this._nubbin}_small`]: !!this._nubbin,
+      [`slds-nubbin_${this._nubbin}`]: true,
       [`slds-popover_${this._size}`]: !!this._size,
       [`slds-popover_walkthrough`]: this._variant === 'feature',
       [`slds-popover_${this._variant}`]: !!this._variant,
+    });
+
+    const [direction, align] = this._nubbin.split('-');
+    this.hostService.updateStyle(this.element, {
+      [direction]: '1rem',
+      [align]: align ? '-1.5rem' : false, // space of nubbin from the edge
     });
   }
 

--- a/projects/ng-lightning/src/lib/tooltips/tooltip.spec.ts
+++ b/projects/ng-lightning/src/lib/tooltips/tooltip.spec.ts
@@ -3,6 +3,7 @@ import { Component, Injectable, OnDestroy, ViewChild } from '@angular/core';
 import { createGenericTestComponent, dispatchEvent } from '../../../test/util';
 import { NglTooltipsModule } from './module';
 import { HostService } from '../common/host/host.service';
+import { expectPlacementStyles } from '../popovers/popover.spec';
 import { NglTooltipTrigger } from './trigger';
 
 const createTestComponent = (html?: string, detectChanges?: boolean) =>
@@ -73,16 +74,29 @@ describe('Tooltips', () => {
     const tooltipEl = getTooltipElement();
 
     expect(tooltipEl).toHaveCssClass('slds-nubbin_bottom');
+    expectPlacementStyles(tooltipEl, { bottom: '1rem' });
 
     componentInstance.placement = 'left';
     fixture.detectChanges();
     expect(tooltipEl).toHaveCssClass('slds-nubbin_right');
     expect(tooltipEl).not.toHaveCssClass('slds-nubbin_bottom');
+    expectPlacementStyles(tooltipEl, { right: '1rem' });
+
+    componentInstance.placement = 'right-top';
+    fixture.detectChanges();
+    expect(tooltipEl).toHaveCssClass('slds-nubbin_left-top');
+    expectPlacementStyles(tooltipEl, { left: '1rem', top: '-1.5rem' });
+
+    componentInstance.placement = 'left-bottom';
+    fixture.detectChanges();
+    expect(tooltipEl).toHaveCssClass('slds-nubbin_right-bottom');
+    expectPlacementStyles(tooltipEl, { right: '1rem', bottom: '-1.5rem' });
 
     componentInstance.placement = 'bottom';
     fixture.detectChanges();
     expect(tooltipEl).toHaveCssClass('slds-nubbin_top');
     expect(tooltipEl).not.toHaveCssClass('slds-nubbin_right');
+    expectPlacementStyles(tooltipEl, { top: '1rem' });
   });
 
   it('should destroy tooltip when host is destroyed', () => {

--- a/projects/ng-lightning/src/lib/tooltips/tooltip.ts
+++ b/projects/ng-lightning/src/lib/tooltips/tooltip.ts
@@ -40,8 +40,13 @@ export class NglTooltip {
 
   private setHostClass() {
     this.hostService.updateClass(this.element, {
-      [`slds-nubbin_${this._nubbin}`]: !!this._nubbin,
-      [`slds-m-${this._nubbin}_small`]: !!this._nubbin,
+      [`slds-nubbin_${this._nubbin}`]: true,
+    });
+
+    const [direction, align] = this._nubbin.split('-');
+    this.hostService.updateStyle(this.element, {
+      [direction]: '1rem',
+      [align]: align ? '-1.5rem' : false, // space of nubbin from the edge
     });
   }
 }

--- a/projects/ng-lightning/src/lib/util/overlay-position.ts
+++ b/projects/ng-lightning/src/lib/util/overlay-position.ts
@@ -13,14 +13,14 @@ export const POSITION_MAP: { [ key: string ]: { position: ConnectionPositionPair
   },
   'top-left': {
     position: new ConnectionPositionPair(
-      { originX: 'start', originY: 'top' },
+      { originX: 'center', originY: 'top' },
       { overlayX: 'start', overlayY: 'bottom' }
     ),
     nubbin: 'bottom-left'
   },
   'top-right': {
     position: new ConnectionPositionPair(
-      { originX: 'end', originY: 'top' },
+      { originX: 'center', originY: 'top' },
       { overlayX: 'end', overlayY: 'bottom' }
     ),
     nubbin: 'bottom-right'
@@ -34,14 +34,14 @@ export const POSITION_MAP: { [ key: string ]: { position: ConnectionPositionPair
   },
   'right-top': {
     position: new ConnectionPositionPair(
-      { originX: 'end', originY: 'top' },
+      { originX: 'end', originY: 'center' },
       { overlayX: 'start', overlayY: 'top' }
     ),
     nubbin: 'left-top'
   },
   'right-bottom': {
     position: new ConnectionPositionPair(
-      { originX: 'end', originY: 'bottom' },
+      { originX: 'end', originY: 'center' },
       { overlayX: 'start', overlayY: 'bottom' }
     ),
     nubbin: 'left-bottom'
@@ -55,14 +55,14 @@ export const POSITION_MAP: { [ key: string ]: { position: ConnectionPositionPair
   },
   'bottom-left': {
     position: new ConnectionPositionPair(
-      { originX: 'start', originY: 'bottom' },
+      { originX: 'center', originY: 'bottom' },
       { overlayX: 'start', overlayY: 'top' }
     ),
     nubbin: 'top-left'
   },
   'bottom-right': {
     position: new ConnectionPositionPair(
-      { originX: 'end', originY: 'bottom' },
+      { originX: 'center', originY: 'bottom' },
       { overlayX: 'end', overlayY: 'top' }
     ),
     nubbin: 'top-right'
@@ -76,14 +76,14 @@ export const POSITION_MAP: { [ key: string ]: { position: ConnectionPositionPair
   },
   'left-top': {
     position: new ConnectionPositionPair(
-      { originX: 'start', originY: 'top' },
+      { originX: 'start', originY: 'center' },
       { overlayX: 'end', overlayY: 'top' }
     ),
     nubbin: 'right-top'
   },
   'left-bottom': {
     position: new ConnectionPositionPair(
-      { originX: 'start', originY: 'bottom' },
+      { originX: 'start', originY: 'center' },
       { overlayX: 'end', overlayY: 'bottom' }
     ),
     nubbin: 'right-bottom'

--- a/src/app/components/popovers/docs/API.md
+++ b/src/app/components/popovers/docs/API.md
@@ -6,7 +6,7 @@
 | `[nglPopoverHeader]` | The header as string or the connected template reference to show. | string \| TemplateRef | |
 | `[nglPopoverFooter]` | The footer as string or the connected template reference to show. | string \| TemplateRef | |
 | `[nglPopoverOpen]` | Whether the floating popover is visible. Be sure to use two-way binding, for example: `[(nglPopoverOpen)]="open"`. | boolean | |
-| `[nglPopoverPlacement]` | Position relative to host element. | 'top' \| 'right' \| 'bottom' \| 'left' | 'top' |
+| `[nglPopoverPlacement]` | Position relative to host element. | 'top' \| 'top-left' \| 'top-right' \| 'right' \| 'right-top' \| 'right-bottom' \| 'bottom' \| 'bottom-left' \| 'bottom-right' \| 'left' \| 'left-top' \| 'left-bottom' | 'top' |
 | `[nglPopoverVariant]` | Determines the variant of the popover. |  'walkthrough' \| 'feature' \| 'warning' \| 'error' \| 'panel' | |
 | `[nglPopoverSize]` | Determines the size of the popover. | 'small' \| 'medium' \| 'large' \| 'full-width' | |
 | `(nglPopoverOpenChange)` | Emit an event when the popover should show or hide. | boolean \| 'x' \| 'backdrop' \| 'escape' |

--- a/src/app/components/popovers/examples/basic.pug
+++ b/src/app/components/popovers/examples/basic.pug
@@ -3,10 +3,8 @@
 
 .slds-text-title_caps.slds-m-bottom_small.slds-m-top_x-large Placement
 .slds-button-group(role='group')
-  button(type="button", nglButton="neutral", [nglPopover]="tip", nglPopoverPlacement="top", [(nglPopoverOpen)]="open.top") Top
-  button(type="button", nglButton="neutral", [nglPopover]="tip", nglPopoverPlacement="right", [(nglPopoverOpen)]="open.right") Right
-  button(type="button", nglButton="neutral", [nglPopover]="tip", nglPopoverPlacement="bottom", [(nglPopoverOpen)]="open.bottom") Bottom
-  button(type="button", nglButton="neutral", [nglPopover]="tip", nglPopoverPlacement="left", [(nglPopoverOpen)]="open.left") Left
+  each val in ['top', 'top-left', 'top-right', 'right', 'right-top', 'right-bottom', 'bottom', 'bottom-left', 'bottom-right', 'left', 'left-top', 'left-bottom']
+    button(type="button", nglButton="neutral", [nglPopover]="tip", nglPopoverPlacement=val, [(nglPopoverOpen)]=`open['${val}']`) #{val}
 
 .slds-text-title_caps.slds-m-bottom_small.slds-m-top_x-large Size
 .slds-button-group(role='group')

--- a/src/app/components/tooltips/docs/API.md
+++ b/src/app/components/tooltips/docs/API.md
@@ -4,7 +4,7 @@
 | -------- | ----------- | ---- | ------- |
 | `[nglTooltip]` | The content as string or the connected template reference to show. | string \| TemplateRef | |
 | `[nglTooltipOpen]` | Whether the floating tooltip is visible. Be sure to use two-way binding, for example: `[(nglTooltipOpen)]="open"` | boolean | |
-| `[nglTooltipPlacement]` | Position relative to host element. | 'top' \| 'right' \| 'bottom' \| 'left' | 'top' |
+| `[nglTooltipPlacement]` | Position relative to host element. | 'top' \| 'top-left' \| 'top-right' \| 'right' \| 'right-top' \| 'right-bottom' \| 'bottom' \| 'bottom-left' \| 'bottom-right' \| 'left' \| 'left-top' \| 'left-bottom' | 'top' |
 | `[nglTooltipDelay]` | Delay in milliseconds until it opens/closes. If you wish to specify different delays for opening and closing, you may provide an array of two different values. | number \| number[] | |
 | `[nglTooltipInteractive]` | Give the possibility to interact with the content of the tooltip. User has to move the cursor to the tooltip before it starts closing (this lapse of time has its duration set by the nglTooltipDelay option). | boolean | false |
 | `(nglTooltipOpenChange)` | Emit an event when the tooltip should show or hide. | boolean | |

--- a/src/app/components/tooltips/examples/basic.pug
+++ b/src/app/components/tooltips/examples/basic.pug
@@ -11,14 +11,11 @@ div
   | Sed
   a([nglTooltip]="tip", [nglTooltipPlacement]="placement", [(nglTooltipOpen)]="open")  hover
   |   vehicula sapien, vitae tristique nisl viverra vitae. Aliquam erat volutpat. Ut accumsan metus vel hendrerit sagittis.
+.slds-button-group.slds-m-top_xx-large(role="group")
+  button(type="button", (click)="change()", nglButton="neutral") Change placement
+  button(type="button", (click)="open = !open", nglButton="neutral") Toggle
 .slds-m-top_x-large
   span(nglTooltip="...which always keep showing!", nglTooltipOpen="true", nglTooltipPlacement="right") You can also make tooltips
-.slds-button-group.slds-m-top_xx-large(role="group")
-  button(type="button", (click)="change('top')", nglButton="neutral") Top
-  button(type="button", (click)="change('left')", nglButton="neutral") Left
-  button(type="button", (click)="change('right')", nglButton="neutral") Right
-  button(type="button", (click)="change('bottom')", nglButton="neutral") Bottom
-  button(type="button", (click)="open = !open", nglButton="neutral") Toggle
 .slds-text-title_caps.slds-m-bottom_small.slds-m-top_x-large Open and close with delay
 button(type="button", nglButton="neutral", nglTooltip="I open and close with 1 second delay...", nglTooltipDelay="1000", [(nglTooltipOpen)]="open1", #x="nglTooltip") Hover or Focus
 .slds-m-top_medium

--- a/src/app/components/tooltips/examples/basic.ts
+++ b/src/app/components/tooltips/examples/basic.ts
@@ -6,13 +6,17 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DemoTooltipsBasic {
-  placement = 'top';
+
+  placements = ['top', 'right', 'bottom', 'left'];
+
+  placement = this.placements[0];
+
   open = true;
   open1 = false;
   open2 = true;
 
-  change(placement: string) {
-    this.open = true;
-    this.placement = placement;
+  change() {
+    const i = this.placements.indexOf(this.placement);
+    this.placement = this.placements[(i + 1) % 4];
   }
 }

--- a/src/app/components/tooltips/examples/placement.pug
+++ b/src/app/components/tooltips/examples/placement.pug
@@ -1,0 +1,27 @@
+.slds-text-title_caps Placement
+
+ng-template(#tip)
+  | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer bibendum dapibus nulla ac imperdiet.
+  | Aenean ut efficitur nunc.
+
+.slds-m-around_xx-large(style="max-width: 600px;")
+  .slds-grid.slds-grid_align-center.slds-gutters_direct-medium
+    button(type="button", nglButton, nglTooltipPlacement='top-left', [nglTooltip]="tip", [(nglTooltipOpen)]="open.tl") top-left
+    button(type="button", nglButton, nglTooltipPlacement='top', [nglTooltip]="tip", [(nglTooltipOpen)]="open.t") top
+    button(type="button", nglButton, nglTooltipPlacement='top-right', [nglTooltip]="tip", [(nglTooltipOpen)]="open.tr") top-right
+  .slds-grid.slds-grid_align-spread
+    .slds-col
+      .slds-grid.slds-grid_vertical
+        span.slds-m-bottom_xx-small: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='left-top', [nglTooltip]="tip", [(nglTooltipOpen)]="open.lt") left-top
+        span.slds-m-bottom_xx-small: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='left', [nglTooltip]="tip", [(nglTooltipOpen)]="open.l") left
+        span: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='left-bottom', [nglTooltip]="tip", [(nglTooltipOpen)]="open.lb") left-bottom
+    .slds-col
+      .slds-grid.slds-grid_vertical.slds-grid_align-end
+        span.slds-m-bottom_xx-small: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='right-top', [nglTooltip]="tip", [(nglTooltipOpen)]="open.rt") right-top
+        span.slds-m-bottom_xx-small: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='right', [nglTooltip]="tip", [(nglTooltipOpen)]="open.r") right
+        span: button.slds-button_stretch(type="button", nglButton, nglTooltipPlacement='right-bottom', [nglTooltip]="tip", [(nglTooltipOpen)]="open.rb") right-bottom
+  .slds-grid.slds-grid_align-center.slds-gutters_direct-medium
+    button(type="button", nglButton, nglTooltipPlacement='bottom-left', [nglTooltip]="tip", [(nglTooltipOpen)]="open.bl") bottom-left
+    button(type="button", nglButton, nglTooltipPlacement='bottom', [nglTooltip]="tip", [(nglTooltipOpen)]="open.b") bottom
+    button(type="button", nglButton, nglTooltipPlacement='bottom-right', [nglTooltip]="tip", [(nglTooltipOpen)]="open.br") bottom-right
+

--- a/src/app/components/tooltips/examples/placement.ts
+++ b/src/app/components/tooltips/examples/placement.ts
@@ -1,0 +1,10 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-demo-tooltips-placement',
+  templateUrl: './placement.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DemoTooltipsPlacement {
+  open = {};
+}

--- a/src/app/components/tooltips/tooltips.module.ts
+++ b/src/app/components/tooltips/tooltips.module.ts
@@ -8,6 +8,7 @@ import { DemoTooltipsComponent } from './tooltips.component';
 
 // Examples
 import { DemoTooltipsBasic } from './examples/basic';
+import { DemoTooltipsPlacement } from './examples/placement';
 
 const routes: Routes = [
   { path: '', component: DemoTooltipsComponent },
@@ -23,6 +24,7 @@ const routes: Routes = [
   declarations: [
     DemoTooltipsComponent,
     DemoTooltipsBasic,
+    DemoTooltipsPlacement,
   ],
 })
 export class NglDemoTooltipsModule {}


### PR DESCRIPTION
New positions supported are: 'top-left', 'top-right', 'right-top', 'right-bottom', 'bottom-left', 'bottom-right', 'left-top' and 'left-bottom'