### PR TITLE
refactor(modals): use `body-scroll-lock` instead of `BlockScrollStrat…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@angular/platform-browser": "^7.2.10",
     "@angular/platform-browser-dynamic": "^7.2.10",
     "@angular/router": "^7.2.10",
+    "body-scroll-lock": "^2.6.1",
     "classlist.js": "^1.1.20150312",
     "core-js": "^2.6.3",
     "rxjs": "~6.4.0",

--- a/projects/ng-lightning/package.json
+++ b/projects/ng-lightning/package.json
@@ -18,6 +18,9 @@
   ],
   "author": "Tasos Bekos <tbekos@gmail.com>",
   "license": "MIT",
+  "dependencies": {
+    "body-scroll-lock": "^2.6.1"
+  },
   "peerDependencies": {
     "@angular/cdk": "^7.0.0",
     "@angular/common": "^7.0.0",

--- a/projects/ng-lightning/src/lib/modals/modal.ts
+++ b/projects/ng-lightning/src/lib/modals/modal.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, ElementRef, EventEmitter, HostListener, Conte
          ChangeDetectionStrategy, Inject, OnChanges, SimpleChanges, AfterContentInit, OnDestroy } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { FocusTrap, FocusTrapFactory } from '@angular/cdk/a11y';
-import { BlockScrollStrategy, ViewportRuler } from '@angular/cdk/overlay';
+import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import { uniqueId } from '../util/util';
 import { InputBoolean } from '../util/convert';
 import { NglModalHeaderTemplate, NglModalTaglineTemplate, NglModalFooterTemplate } from './templates';
@@ -52,11 +52,7 @@ export class NglModal implements OnChanges, AfterContentInit, OnDestroy {
   /** Element that was focused before the dialog was opened. Save this to restore upon close. */
   private elementFocusedBeforeDialogWasOpened: HTMLElement | null = null;
 
-  private scrollStrategy: BlockScrollStrategy;
-
-  constructor(private focusTrapFactory: FocusTrapFactory, viewportRuler: ViewportRuler, @Inject(DOCUMENT) private document: any, private element: ElementRef) {
-    this.scrollStrategy = new BlockScrollStrategy(viewportRuler, document);
-  }
+  constructor(private focusTrapFactory: FocusTrapFactory, @Inject(DOCUMENT) private document: any, private element: ElementRef) {}
 
   @HostListener('keydown.esc', ['$event'])
   close(evt?: Event) {
@@ -90,7 +86,6 @@ export class NglModal implements OnChanges, AfterContentInit, OnDestroy {
 
   ngOnDestroy() {
     this.handleOpen(false);
-    this.scrollStrategy = null;
   }
 
   modalClass() {
@@ -123,7 +118,7 @@ export class NglModal implements OnChanges, AfterContentInit, OnDestroy {
 
       this.focusTrap = this.focusTrapFactory.create(this.element.nativeElement);
       this.focusTrap.focusInitialElementWhenReady();
-      this.scrollStrategy.enable();
+      disableBodyScroll(undefined, { reserveScrollBarGap: true });
     } else {
       if (this.elementFocusedBeforeDialogWasOpened && typeof this.elementFocusedBeforeDialogWasOpened.focus === 'function') {
         this.elementFocusedBeforeDialogWasOpened.focus();
@@ -131,7 +126,7 @@ export class NglModal implements OnChanges, AfterContentInit, OnDestroy {
       if (this.focusTrap) {
         this.focusTrap.destroy();
       }
-      this.scrollStrategy.disable();
+      enableBodyScroll();
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1336,6 +1336,11 @@ body-parser@1.18.3, body-parser@^1.16.1:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+body-scroll-lock@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.1.tgz#3782ff37404886faaee366968ceee40c3964d8f2"
+  integrity sha512-fsDsq10+BJrk/+eGADqxspyZpGiKSh3dK8ByE6KuDK0REmPB99U05p1t9xVTAM9J6j9PJGm6W/W+HsCPnOFj+Q==
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"


### PR DESCRIPTION
…egy` of CDK

Angular CDK is using the `position: fixed` approach which causes the body scroll to reset, and will make our effort to move to popper.js for placements impossible.