### PR TITLE
fix(paginations): show correct `start` and `end` values when `current` is undefined

### DIFF
--- a/projects/ng-lightning/src/lib/paginations/pagination.ts
+++ b/projects/ng-lightning/src/lib/paginations/pagination.ts
@@ -83,7 +83,7 @@ export class NglPagination implements OnChanges {
   }
 
   get start(): number {
-    return Math.min(Math.max(1 + (+this.current - 1) * +this.perPage, 0), +this.total);
+    return Math.min(Math.max(1 + ((+this.current || 1) - 1) * +this.perPage, 0), +this.total);
   }
 
   get end(): number {

--- a/projects/ng-lightning/src/lib/paginations/paginations.spec.ts
+++ b/projects/ng-lightning/src/lib/paginations/paginations.spec.ts
@@ -215,6 +215,10 @@ describe('Pagination Component', () => {
     fixture.detectChanges();
     expect(el).toHaveText('31 - 33');
 
+    fixture.componentInstance.page = undefined;
+    fixture.detectChanges();
+    expect(el).toHaveText('1 - 10');
+
     fixture.componentInstance.total = 0;
     fixture.detectChanges();
     expect(el).toHaveText('0 - 0');


### PR DESCRIPTION
Since `page` is two-way bindable, it's actually quite common for it to be `undefined` initially. The component even supports automatically going to page 1 in this case. The start and end values, however, are calculated incorrectly for this scenario. This commit fixes that.

Visually speaking, it fixes this:
![image](https://user-images.githubusercontent.com/1123672/110482718-3c293180-80e9-11eb-9474-84d10c88f842.png)