### PR TITLE
Update the selection value when options change

### DIFF
--- a/projects/ng-lightning/src/lib/comboboxes/combobox.ts
+++ b/projects/ng-lightning/src/lib/comboboxes/combobox.ts
@@ -147,7 +147,7 @@ export class NglCombobox implements OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.selection) {
+    if (changes.selection || changes.data) {
       this.calculateDisplayValue();
     }
   }


### PR DESCRIPTION
There is a bug in the combobox that when the options are received after the selection, the label of the selection doesn't appear. 