### PR TITLE
feat(app) add nightly builds

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,25 @@
+name: Nightly build
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+      - run: npm ci
+      - run: npm run lib:build
+      - name: Pushes to nightly repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'dist/ng-lightning'
+          destination-github-username: 'ng-lightning'
+          destination-repository-name: 'builds'
+          user-email: tbekos@gmail.com
+          target-branch: main


### PR DESCRIPTION
This PR add an action that build the project and push the dist folder into ng-lightning/build repository every time there is any change in master.  Details: https://github.com/cpina/github-action-push-to-another-repository
Anyone will be able to use/test the nightly version package with 'npm i github:ng-lightning/build'.

We need to:

1. create the new repo ng-lightning/build
2. create a personal access token for the user we want to make the push.
3. configure a API_TOKEN_GITHUB secret in ng-lightning/ng-lightning with the token

I'd like to point that I have tested a similar code in my repo but since it cannot be tested here until it reaches master there is a small risk of failure after merging.

@bekos I don't have permissions to create the new repo or modify the settings for this one, and probably i shouldn't have them anyway. Could you do it?

Thanks