### PR TITLE
chore(app): enable strictInputAccessModifiers in tsconfig

### DIFF
--- a/projects/ng-lightning/src/lib/carousel/carousel.ts
+++ b/projects/ng-lightning/src/lib/carousel/carousel.ts
@@ -16,7 +16,7 @@ import { NglCarouselIndicator } from './carousel-indicator';
 })
 export class NglCarousel implements OnChanges {
 
-  @Input() @InputNumber() readonly active;
+  @Input() @InputNumber() active;
 
   @Output() activeChange = new EventEmitter<number>();
 
@@ -41,7 +41,7 @@ export class NglCarousel implements OnChanges {
 
   @ViewChild('indicatorsEl', { static: true }) indicatorsEl: ElementRef<HTMLElement>;
 
-  @Input() readonly labels = {
+  @Input() labels = {
     startAutoPlay: 'Start auto-play',
     stopAutoPlay: 'Stop auto-play',
   };

--- a/projects/ng-lightning/src/lib/comboboxes/combobox.ts
+++ b/projects/ng-lightning/src/lib/comboboxes/combobox.ts
@@ -29,31 +29,31 @@ export interface NglComboboxOptionItem {
 })
 export class NglCombobox implements OnChanges, OnDestroy {
 
-  @Input() readonly variant: 'base' | 'lookup' = 'base';
+  @Input() variant: 'base' | 'lookup' = 'base';
 
-  @Input() readonly label: string | TemplateRef<any>;
+  @Input() label?: string | TemplateRef<any>;
 
   readonly uid = uniqueId('combobox');
 
-  @Input() @InputBoolean() readonly open = false;
+  @Input() @InputBoolean() open = false;
 
   @Output() openChange = new EventEmitter<boolean>();
 
-  @Input() readonly selection: any;
+  @Input() selection: any;
 
   @Output() selectionChange = new EventEmitter();
 
-  @Input() @InputBoolean() readonly multiple = false;
+  @Input() @InputBoolean() multiple = false;
 
-  @Input() @InputNumber() readonly visibleLength: 5 | 7 | 10 = 5;
+  @Input() @InputNumber() visibleLength: 5 | 7 | 10 = 5;
 
-  @ContentChild(NglComboboxInput, { static: true }) inputEl: NglComboboxInput;
+  @ContentChild(NglComboboxInput, { static: true }) inputEl?: NglComboboxInput;
 
-  @Input() @InputBoolean() readonly loading: boolean;
+  @Input() @InputBoolean() loading?: boolean;
 
-  @Input() @InputBoolean() readonly loadingMore: boolean;
+  @Input() @InputBoolean() loadingMore?: boolean;
 
-  @Input() @InputBoolean() readonly closeOnSelection = true;
+  @Input() @InputBoolean() closeOnSelection = true;
 
   /**
    * Text added to loading spinner.
@@ -70,7 +70,7 @@ export class NglCombobox implements OnChanges, OnDestroy {
    */
   @Input() removeSelectedLabel: string;
 
-  @ViewChildren(NglComboboxOption) readonly options: QueryList<NglComboboxOption>;
+  @ViewChildren(NglComboboxOption) readonly options?: QueryList<NglComboboxOption>;
 
   @Input('options') set data(data: any[]) {
     this._data = (data || []).map((d) => {
@@ -85,27 +85,27 @@ export class NglCombobox implements OnChanges, OnDestroy {
     });
   }
   get data() {
-    return this._data;
+    return this._data as any[];
   }
 
-  @ViewChild('overlayOrigin', { static: true }) overlayOrigin: CdkOverlayOrigin;
+  @ViewChild('overlayOrigin', { static: true }) overlayOrigin?: CdkOverlayOrigin;
 
-  @ViewChild('cdkOverlay') cdkOverlay: CdkConnectedOverlay;
+  @ViewChild('cdkOverlay') cdkOverlay?: CdkConnectedOverlay;
 
-  @ViewChild('dropdown') dropdownElementRef: ElementRef;
+  @ViewChild('dropdown') dropdownElementRef?: ElementRef;
 
   overlayWidth = 0;
 
   overlayPositions: ConnectionPositionPair[] = [...DEFAULT_DROPDOWN_POSITIONS['left']];
 
   /** Manages active item in option list based on key events. */
-  keyManager: ActiveDescendantKeyManager<NglComboboxOption>;
+  keyManager?: ActiveDescendantKeyManager<NglComboboxOption> | null;
 
-  private optionChangesSubscription: Subscription;
+  private optionChangesSubscription?: Subscription | null;
 
-  private _data: NglComboboxOptionItem[] | null;
+  private _data?: NglComboboxOptionItem[] | null;
 
-  private keyboardSubscription: Subscription;
+  private keyboardSubscription?: Subscription | null;
 
   @Input() selectionValueFn = (selection: string[]): string => {
     if (selection.length > 0) {
@@ -154,27 +154,27 @@ export class NglCombobox implements OnChanges, OnDestroy {
 
   onAttach() {
     // Same width as the trigger element
-    this.overlayWidth = this.overlayOrigin.elementRef.nativeElement.offsetWidth;
+    this.overlayWidth = this.overlayOrigin?.elementRef.nativeElement.offsetWidth;
     this.cd.detectChanges();
 
-    this.keyManager = new ActiveDescendantKeyManager(this.options).withWrap();
+    this.keyManager = this.options && new ActiveDescendantKeyManager(this.options).withWrap();
 
     // Activate selected item or first option
-    const selectedOption = this.options.find(o => o.selected);
+    const selectedOption = this.options?.find(o => o.selected);
     if (selectedOption) {
-      this.keyManager.setActiveItem(selectedOption);
+      this.keyManager?.setActiveItem(selectedOption);
     } else {
-      this.keyManager.setFirstItemActive();
+      this.keyManager?.setFirstItemActive();
     }
 
     // Listen to button presses if picklist to activate matching option
     this.keyboardSubscribe(this.variant === 'base');
 
     // When it is open we listen for option changes in order to fix active option and handle scroll
-    this.optionChangesSubscription = this.options.changes.subscribe(() => {
-      if (!this.activeOption || this.options.toArray().indexOf(this.activeOption) === -1) {
+    this.optionChangesSubscription = this.options?.changes.subscribe(() => {
+      if (!this.activeOption || this.options?.toArray().indexOf(this.activeOption) === -1) {
         // Activate first option if active one is destroyed
-        this.keyManager.setFirstItemActive();
+        this.keyManager?.setFirstItemActive();
       } else {
         this.activeOption.scrollIntoView();
       }
@@ -192,12 +192,12 @@ export class NglCombobox implements OnChanges, OnDestroy {
     }
 
     // Clear aria-activedescendant when menu is closed
-    this.inputEl.setAriaActiveDescendant(null);
+    this.inputEl?.setAriaActiveDescendant(null);
 
     this.detach();
   }
 
-  trackByOption(index, option: NglComboboxOption) {
+  trackByOption(_index: number, option: NglComboboxOption) {
     return option.value;
   }
 
@@ -215,18 +215,20 @@ export class NglCombobox implements OnChanges, OnDestroy {
     return this.isLookup && this.data.length === 0 && !this.loadingMore;
   }
 
-  onOptionSelection(option: NglComboboxOption = this.activeOption) {
-    const selection = addOptionToSelection(option.value, this.selection, this.multiple);
-    this.selectionChange.emit(selection);
-    if (this.closeOnSelection) {
-      this.close();
+  onOptionSelection(option: NglComboboxOption | null = this.activeOption) {
+    if (option) {
+      const selection = addOptionToSelection(option.value, this.selection, this.multiple);
+      this.selectionChange.emit(selection);
+      if (this.closeOnSelection) {
+        this.close();
+      }
     }
   }
 
   // Trigger by clear button on Lookup
   onClearSelection() {
     this.selectionChange.emit(null);
-    setTimeout(() => this.inputEl.focus(), 0);
+    setTimeout(() => this.inputEl?.focus(), 0);
   }
 
   /**
@@ -256,8 +258,8 @@ export class NglCombobox implements OnChanges, OnDestroy {
   }
 
   private calculateDisplayValue() {
-    const value = this.selectionValueFn(this.selectedOptions.map(option => option.label));
-    this.inputEl.setValue(value);
+    const value = this.selectionValueFn(this.selectedOptions.map(option => option.label || ''));
+    this.inputEl?.setValue(value);
   }
 
   private keyboardSubscribe(listen: boolean) {
@@ -266,19 +268,22 @@ export class NglCombobox implements OnChanges, OnDestroy {
       this.keyboardSubscription = null;
     }
 
-    if (listen) {
+    if (listen && this.inputEl) {
       this.keyboardSubscription = this.inputEl.keyboardBuffer$.subscribe((pattern) => {
-        pattern = pattern.toLocaleLowerCase();
+        if (this.options && this.keyManager) {
 
-        const options = this.options.toArray();
+          pattern = pattern.toLocaleLowerCase();
 
-        const activeIndex = this.activeOption ? this.keyManager.activeItemIndex + 1 : 0;
-        for (let i = 0, n = options.length; i < n; i++) {
-          const index = (activeIndex + i) % n;
-          const option = options[index];
-          if (!option.disabled && option.label.toLocaleLowerCase().substr(0, pattern.length) === pattern) {
-            this.keyManager.setActiveItem(option);
-            break;
+          const options = this.options.toArray();
+
+          const activeIndex = this.activeOption ? (this.keyManager.activeItemIndex || 0) + 1 : 0;
+          for (let i = 0, n = options.length; i < n; i++) {
+            const index = (activeIndex + i) % n;
+            const option = options[index];
+            if (!option.disabled && option.label.toLocaleLowerCase().substr(0, pattern.length) === pattern) {
+              this.keyManager.setActiveItem(option);
+              break;
+            }
           }
         }
       });
@@ -287,12 +292,14 @@ export class NglCombobox implements OnChanges, OnDestroy {
 
   private updateMenuHeight() {
     this.ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => {
-      const { overlayRef } = this.cdkOverlay;
-      const height = this.dropdownElementRef.nativeElement.offsetHeight;
-      overlayRef.updateSize({
-        minHeight: height + 4,
-      });
-      overlayRef.updatePosition();
+      if (this.cdkOverlay && this.dropdownElementRef) {
+        const { overlayRef } = this.cdkOverlay;
+        const height = this.dropdownElementRef.nativeElement.offsetHeight;
+        overlayRef.updateSize({
+          minHeight: height + 4,
+        });
+        overlayRef.updatePosition();
+      }
     });
   }
 }

--- a/projects/ng-lightning/src/lib/datepickers/datepicker.ts
+++ b/projects/ng-lightning/src/lib/datepickers/datepicker.ts
@@ -41,44 +41,44 @@ export class NglDatepicker implements OnInit, OnChanges, AfterViewInit {
   }
   @Output() dateChange = new EventEmitter();
 
-  @Input() @InputBoolean() readonly showToday: boolean;
+  @Input() @InputBoolean() showToday: boolean;
 
-  @Input() @InputNumber() readonly firstDayOfWeek: number;
+  @Input() @InputNumber() firstDayOfWeek: number;
 
   /**
    * Offset of year from current year, that can be the minimum option in the year selection dropdown.
    */
-  @Input() readonly relativeYearFrom: number;
+  @Input() relativeYearFrom: number;
 
   /**
    * Offset of year from current year, that can be the maximum option in the year selection dropdown.
    */
-  @Input() readonly relativeYearTo: number;
+  @Input() relativeYearTo: number;
 
   /**
    * The minimum date that can be selected.
    */
-  @Input() readonly min: Date;
+  @Input() min: Date;
 
   /**
    * The maximum date that can be selected.
    */
-  @Input() readonly max: Date;
+  @Input() max: Date;
 
   /**
    * Label of shortcut to select current date.
    */
-  @Input() readonly todayLabel: string;
+  @Input() todayLabel: string;
 
   /**
    * Label for button to go to the previous month.
    */
-  @Input() readonly previousMonthLabel: string;
+  @Input() previousMonthLabel: string;
 
   /**
    * Label for button to go to the next month.
    */
-  @Input() readonly nextMonthLabel: string;
+  @Input() nextMonthLabel: string;
 
 
   weeks: NglInternalDate[];

--- a/projects/ng-lightning/src/lib/datepickers/input/datepicker-input.ts
+++ b/projects/ng-lightning/src/lib/datepickers/input/datepicker-input.ts
@@ -99,17 +99,17 @@ export class NglDatepickerInput implements ControlValueAccessor, Validator, OnIn
   /**
    * The minimum valid date.
    */
-  @Input() readonly min: Date;
+  @Input() min: Date;
 
   /**
    * The maximum valid date.
    */
-  @Input() readonly max: Date;
+  @Input() max: Date;
 
   /**
    * Text for button to open calendar.
    */
-  @Input() readonly selectDateLabel = 'Select a date';
+  @Input() selectDateLabel = 'Select a date';
 
   /**
    * Whether to use the accepted pattern as placeholder.

--- a/projects/ng-lightning/src/lib/datepickers/month.ts
+++ b/projects/ng-lightning/src/lib/datepickers/month.ts
@@ -112,7 +112,7 @@ export class NglDatepickerMonth implements OnChanges {
   }
 
   private daysInNextMonth(year: number, month: number, numOfDays: number) {
-    if (numOfDays % 7 === 0) { return; }
+    if (numOfDays % 7 === 0) { return[]; }
     return this.getDayObjects(year, month, 1, 7 - (numOfDays % 7), false);
   }
 

--- a/projects/ng-lightning/src/lib/datepickers/util.ts
+++ b/projects/ng-lightning/src/lib/datepickers/util.ts
@@ -51,6 +51,7 @@ export function compareDate(d1: NglInternalDate, d2: NglInternalDate) {
       return diff > 0 ? 1 : -1;
     }
   }
+  return 0;
 }
 
 export function isSameMonth(d1: NglInternalDate, d2: NglInternalDate): boolean {

--- a/projects/ng-lightning/src/lib/input/input/input.ts
+++ b/projects/ng-lightning/src/lib/input/input/input.ts
@@ -15,13 +15,13 @@ import { Subscription } from 'rxjs';
 export class NglInput implements OnChanges, AfterContentInit, OnDestroy {
   @ContentChild(NglInputElement, { static: true }) input: NglInputElement;
 
-  @Input() label: string | TemplateRef<any>;
+  @Input() label?: string | TemplateRef<any>;
 
-  @Input() error: string | TemplateRef<any>;
+  @Input() error?: string | TemplateRef<any>;
 
-  @Input() @InputBoolean() stacked: boolean;
+  @Input() @InputBoolean() stacked?: boolean;
 
-  @Input() fieldLevelHelpTooltip: string | TemplateRef<any>;
+  @Input() fieldLevelHelpTooltip?: string | TemplateRef<any>;
 
   @HostBinding('class.slds-has-error')
   get hasError(): boolean {

--- a/projects/ng-lightning/src/lib/tooltips/trigger.ts
+++ b/projects/ng-lightning/src/lib/tooltips/trigger.ts
@@ -67,12 +67,12 @@ export class NglTooltipTrigger implements OnChanges, OnDestroy {
   /**
    * Open/close without two-way binding input.
    */
-  @Input('nglTooltipOpenAuto') @InputBoolean() openAuto: boolean;
+  @Input('nglTooltipOpenAuto') @InputBoolean() openAuto: boolean | string;
 
   /**
    * Gives the possibility to interact with the content of the popover.
    */
-  @Input('nglTooltipInteractive') @InputBoolean() interactive: boolean;
+  @Input('nglTooltipInteractive') @InputBoolean() interactive: boolean | string;
 
   /**
    * Extra class(es) you want to apply to tooltip host element.

--- a/projects/ng-lightning/src/lib/util/overlay-position.ts
+++ b/projects/ng-lightning/src/lib/util/overlay-position.ts
@@ -194,6 +194,7 @@ export function getPlacementName(position: ConnectedOverlayPositionChange, initi
       return placement;
     }
   }
+  return '';
 }
 
 export function getPlacementStyles(nubbin: Placement) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,27 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
-    "downlevelIteration": true,
-    "importHelpers": true,
     "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    // "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
     "declaration": false,
-    "module": "es2020",
-    "moduleResolution": "node",
+    "downlevelIteration": true,
     "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
     "target": "es2015",
-    "typeRoots": [
-      "node_modules/@types"
-    ],
-    "lib": [
-      "es2017",
-      "dom"
-    ],
-    "paths": {
-    }
+    "module": "es2020",
+    "lib": ["es2020", "dom"]
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    // "strictTemplates": true
   }
 }


### PR DESCRIPTION
I have updated the tsconfig.json with a modern angular project configuration to make easier the use of ng-lightning in this type of projects. The initial idea was to enable all properties but i had to comment the strict mode and the strict template mode out because the impact of those options is too big to include all changes in a single PR.
All changes in other files are related with the ts configuration, specially with strictInputAccessModifiers.