### PR TITLE
fix(tooltips): close on escape press

### DIFF
--- a/projects/ng-lightning/src/lib/tooltips/tooltip.spec.ts
+++ b/projects/ng-lightning/src/lib/tooltips/tooltip.spec.ts
@@ -450,6 +450,21 @@ describe('Tooltips', () => {
       fixture.detectChanges();
       expect(componentInstance.cb).toHaveBeenCalledWith(true);
     }));
+
+    it('should close the tooltip when Escape key is pressed', fakeAsync(() => {
+      fixture = createTestComponent();
+      const triggerEl = fixture.nativeElement.firstElementChild;
+      triggerEl.dispatchEvent(new MouseEvent('mouseenter')); // Open the tooltip
+      expect(getTooltipElement()).toBeTruthy(); // Tooltip is open
+      
+      // Simulate Escape key press
+      const escapeEvent = new KeyboardEvent('keyup', { key: 'Escape' });
+      document.dispatchEvent(escapeEvent);
+      tick();
+      fixture.detectChanges();
+      
+      expect(getTooltipElement()).toBeFalsy(); // Tooltip should be closed
+    }));
   });
 });
 

--- a/projects/ng-lightning/src/lib/tooltips/trigger.ts
+++ b/projects/ng-lightning/src/lib/tooltips/trigger.ts
@@ -149,6 +149,12 @@ export class NglTooltipTrigger implements OnChanges, OnDestroy {
     }
   }
 
+  @HostListener("document:keyup.escape", ["$event"])
+  onEscapePress(event: KeyboardEvent) {
+    event.stopPropagation();
+    this.close(0);
+  }
+
   ngOnDestroy(): void {
     this.detach();
     this.close(0);

--- a/src/app/components/tooltips/docs/README.md
+++ b/src/app/components/tooltips/docs/README.md
@@ -7,3 +7,5 @@ Use a `string` or a `<ng-template #ref>` to host your tooltip's content. `#` ref
 If you want to delay the opening and closing of the popover/tooltip, you can use the `nglTooltipDelay` to specify the amount of time in milliseconds.
 
 In case you don't care to handle open/close state of tooltips using `[(nglTooltipOpen)]`, you can opt-in to use `nglTooltipOpenAuto`, and if you want to make it the default behavior you can take advantage of `NGL_TOOLTIP_CONFIG`.
+
+**Note:** The tooltips can be dismissed with an `Escape` key press without moving pointer hover or keyboard focus, following [WCAG2.1](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) accessibility standards.


### PR DESCRIPTION
This PR adds functionality to make tooltips dismissible using the Escape key, in compliance with the [WCAG 2.1 standard](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) for content on hover or focus.

## Changes Made
- Added a @HostListener to listen for the Escape key press and close the tooltip.
- Ensured that the event propagation is stopped to prevent any unintended side effects.
- Made documentation changes to notify any readers of this update
- Added a relevant test case to make sure this functionality works as expected

## Demo

We no longer need to just rely on moving our cursor or focus away from the trigger element for tooltips to be disabled. It is now possible by pressing the `Escape` key on keyboard.
![FixNglTooltipDemo](https://github.com/ng-lightning/ng-lightning/assets/78865303/216b54d9-13b9-4523-845f-455cb2845549)

This fixes #600 